### PR TITLE
Migrate to SDL3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,15 @@ if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
 endif()
 
-find_package(SDL2 REQUIRED)
+find_package(SDL3)
+if(SDL3_FOUND)
+	get_target_property(SDL_INCLUDE_DIR SDL3::Headers INTERFACE_INCLUDE_DIRECTORIES)
+	target_include_directories(SDL3::Headers INTERFACE ${SDL_INCLUDE_DIR}/SDL3)
+	set(SDL_LIBRARY SDL3::SDL3)
+else()
+	find_package(SDL2 REQUIRED)
+	set(SDL_LIBRARY SDL2::SDL2 SDL2::SDL2main)
+endif()
 find_package(PNG REQUIRED)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
@@ -1204,7 +1212,7 @@ target_include_directories(radcore
 	PUBLIC "code/" # wtf (radobject.hpp includes memory/classsizetracker.h)
 )
 target_compile_features(radcore PUBLIC cxx_std_17)
-target_link_libraries(radcore SDL2::SDL2)
+target_link_libraries(radcore ${SDL_LIBRARY})
 
 add_library(radcontent STATIC ${RADCONTENT_SOURCES})
 target_include_directories(radcontent
@@ -1240,7 +1248,7 @@ if(SRR2_P3D_CG)
 	target_link_libraries(pddi cg cgGL)
 endif()
 target_link_libraries(pddi
-	SDL2::SDL2
+	${SDL_LIBRARY}
 	radmath
 	radcore
 )
@@ -1308,7 +1316,7 @@ if(SRR2_BUILD_TESTS)
 		"code/main/tuidunaligned.cpp")
 	target_link_libraries(simplemovie
 		radmovie
-		SDL2::SDL2
+		${SDL_LIBRARY}
 		p3d
 		pddi
 		radcore
@@ -1436,8 +1444,7 @@ endif()
 
 add_executable(${PROJECT_NAME} ${SRR2_SOURCES})
 target_link_libraries(${PROJECT_NAME}
-	SDL2::SDL2
-	SDL2::SDL2main
+	${SDL_LIBRARY}
 	choreo
 	p3d
 	pddi

--- a/code/main/game.cpp
+++ b/code/main/game.cpp
@@ -506,7 +506,11 @@ void Game::Run()
         SDL_Event msg;
         while( SDL_PollEvent( &msg ) )
         {
+#if SDL_MAJOR_VERSION < 3
             if( msg.type == SDL_QUIT )
+#else
+            if( msg.type == SDL_EVENT_QUIT )
+#endif
             {
                 //Chuck someone closed the Window we are going to try to exit the game 
                 //if the game isnt in a context that can easily transition to the EXIT context we 

--- a/code/main/win32main.cpp
+++ b/code/main/win32main.cpp
@@ -93,9 +93,15 @@ extern "C" int main( int argc, char *argv[] )
     //
     // Initialize SDL subsystems
     //
+#if SDL_MAJOR_VERSION < 3
     SDL_Init( SDL_INIT_EVENTS | SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER );
-	
+
     SDL_LogSetOutputFunction( LogOutputFunction, NULL );
+#else
+    SDL_Init( SDL_INIT_EVENTS | SDL_INIT_VIDEO | SDL_INIT_GAMEPAD );
+
+    SDL_SetLogOutputFunction( LogOutputFunction, NULL );
+#endif
 
     //
     // Have to get FTech setup first so that we can use all the memory services.

--- a/code/main/win32platform.cpp
+++ b/code/main/win32platform.cpp
@@ -338,7 +338,11 @@ bool Win32Platform::InitializeWindow()
 #endif
     int w, h;
     TranslateResolution( StartingResolution, w, h );
+#if SDL_MAJOR_VERSION < 3
     mWnd = SDL_CreateWindow( ApplicationName, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h, flags );
+#else
+    mWnd = SDL_CreateWindow( ApplicationName, w, h, flags );
+#endif
 
     rAssert(mWnd != NULL);
 
@@ -349,7 +353,9 @@ bool Win32Platform::InitializeWindow()
 
     ShowTheCursor( false );
 
+#if SDL_MAJOR_VERSION < 3
     SDL_GetWindowGammaRamp( mWnd, DesktopGammaRamp[0], DesktopGammaRamp[1], DesktopGammaRamp[2] );
+#endif
 
     SDL_DisableScreenSaver();
 
@@ -1798,7 +1804,14 @@ void Win32Platform::ShowTheCursor( bool show )
     if( mShowCursor != show )
     {        
         mShowCursor = show;
+#if SDL_MAJOR_VERSION < 3
         SDL_ShowCursor( mShowCursor ? SDL_ENABLE : SDL_DISABLE );
+#else
+        if( mShowCursor )
+            SDL_ShowCursor();
+        else
+            SDL_HideCursor();
+#endif
     }
 }
 
@@ -1818,13 +1831,22 @@ void Win32Platform::ShowTheCursor( bool show )
 // Notes:
 //=============================================================================
 
+#if SDL_MAJOR_VERSION < 3
 int SDLCALL Win32Platform::WndProc( void * userdata, SDL_Event * event )
+#else
+bool SDLCALL Win32Platform::WndProc( void * userdata, SDL_Event * event )
+#endif
 {
     SDL_Window * wnd = (SDL_Window *)userdata;
 
     switch(event->type)
     {
+#if SDL_MAJOR_VERSION < 3
     case SDL_WINDOWEVENT: // WM_ACTIVATEAPP
+#else
+    default: // WM_ACTIVATEAPP
+        if( event->type >= SDL_EVENT_WINDOW_FIRST && event->type <= SDL_EVENT_WINDOW_LAST )
+#endif
         {
             //
             // Under Win32, Pure3D needs to get a crack at the Windows messages so
@@ -1832,11 +1854,11 @@ int SDLCALL Win32Platform::WndProc( void * userdata, SDL_Event * event )
             //
             p3d::platform->ProcessWindowsMessage( wnd, &event->window );
 
-            InputManager* pInputManager = GetInputManager();
-
             if( spInstance != NULL && spInstance->mpContext != NULL )
             {
-                switch(event->window.event)
+                InputManager* pInputManager = GetInputManager();
+#if SDL_MAJOR_VERSION < 3
+                switch( event->window.event )
                 {
                 case SDL_WINDOWEVENT_FOCUS_GAINED: // Window is being shown (in focus)
                     {
@@ -1871,16 +1893,58 @@ int SDLCALL Win32Platform::WndProc( void * userdata, SDL_Event * event )
                 }
 
                 ShowTheCursor( event->window.event == SDL_WINDOWEVENT_FOCUS_LOST );
+#else
+                switch( event->window.type )
+                {
+                case SDL_EVENT_WINDOW_FOCUS_GAINED: // Window is being shown (in focus)
+                    {
+                        RenderFlow* rf = GetRenderFlow();
+
+                        rf->SetGamma( rf->GetGamma() );
+                        if( pInputManager )
+                        {
+                            //GetInputManager()->SetRumbleForDevice(0, true);
+                            //rDebugPrintf("Force Effects Started!!! \n");
+                        }
+                    }
+                    SDL_HideCursor();
+                    break;
+
+                case SDL_EVENT_WINDOW_FOCUS_LOST:  // Window is being hidden (not in focus)
+                    if( pInputManager )
+                    {
+                        //GetInputManager()->SetRumbleForDevice(0, false);
+                        //rDebugPrintf("Force Effects Stopped!!! \n");
+                    }
+                    SDL_ShowCursor();
+                    break;
+
+#ifdef RAD_PC
+                case SDL_EVENT_WINDOW_LEAVE:
+                    GetInputManager()->GetFEMouse()->getCursor()->SetVisible( false );
+                    break;
+#endif
+                }
+#endif
             }
 
             break;
         }
 
+#if SDL_MAJOR_VERSION < 3
     case SDL_KEYDOWN: // WM_SYSKEYDOWN
     case SDL_KEYUP:   // WM_SYSKEYUP
+#else
+    case SDL_EVENT_KEY_DOWN: // WM_SYSKEYDOWN
+    case SDL_EVENT_KEY_UP:   // WM_SYSKEYUP
+#endif
         {
             //Ignore Alt and F10 keys.
-            switch(event->key.keysym.sym) 
+#if SDL_MAJOR_VERSION < 3
+            switch( event->key.keysym.sym )
+#else
+            switch( event->key.key )
+#endif
             {
             case SDLK_LALT:
             case SDLK_RALT:
@@ -1891,7 +1955,11 @@ int SDLCALL Win32Platform::WndProc( void * userdata, SDL_Event * event )
             }
         }
 
-    case SDL_MOUSEMOTION:  
+#if SDL_MAJOR_VERSION < 3
+    case SDL_MOUSEMOTION:
+#else
+    case SDL_EVENT_MOUSE_MOTION:
+#endif
         {
 #ifdef RAD_PC
             // For some reason beyond my comprehension WM_MOUSEMOVE seems to be getting called regardless if the
@@ -1930,9 +1998,6 @@ int SDLCALL Win32Platform::WndProc( void * userdata, SDL_Event * event )
         // regains focus, WM_PDDI_DRAW_ENABLE(1) will be sent.
     //case WM_PDDI_DRAW_ENABLE:
         //GetApplication()->EnableRendering(wParam == 1);
-        break;
-
-    default:
         break;
     }
 

--- a/code/main/win32platform.h
+++ b/code/main/win32platform.h
@@ -136,7 +136,11 @@ private:
     // Windows methods.
     void ResizeWindow();
     static void ShowTheCursor( bool show );
+#if SDL_MAJOR_VERSION < 3
     static int SDLCALL WndProc( void* userdata, SDL_Event* msg );
+#else
+    static bool SDLCALL WndProc( void* userdata, SDL_Event* msg );
+#endif
 
 private:
 

--- a/libs/pure3d/pddi/gl/display_linux/gldisplay.cpp
+++ b/libs/pure3d/pddi/gl/display_linux/gldisplay.cpp
@@ -170,14 +170,6 @@ unsigned pglDisplay::Screenshot(pddiColour* buffer, int nBytes)
     // not implemented under linux
     assert(0 && "PDDI: pddiDisplay::ScreenShot() - Not implemented under linux.");
 }
-
-unsigned pglDisplay::FillDisplayModes(pddiModeInfo* displayModes)
-{
-    int i = 0;
-    int nModes = 0;
-
-    return nModes;
-}
     
 void pglDisplay::BeginTiming()
 {

--- a/libs/pure3d/pddi/gl/display_linux/gldisplay.hpp
+++ b/libs/pure3d/pddi/gl/display_linux/gldisplay.hpp
@@ -57,8 +57,6 @@ public:
     bool CheckExtension(char*);
     bool HasReset(void) { return reset; }
 
-    static unsigned FillDisplayModes(pddiModeInfo*);
-
     void BeginContext(void);
     void EndContext(void);
 

--- a/libs/pure3d/pddi/gl/display_sgi/gldisplay.cpp
+++ b/libs/pure3d/pddi/gl/display_sgi/gldisplay.cpp
@@ -291,14 +291,3 @@ pddiLockInfo*  pglSurface::Lock(pddiLockType l)
 void pglSurface::Unlock()
 {
 }
-
-unsigned pglDisplay::FillDisplayModes(pddiModeInfo* displayModes)
-{
-    int i = 0;
-    int nModes = 0;
-
-    return nModes;
-}
-    
-
-

--- a/libs/pure3d/pddi/gl/display_sgi/gldisplay.hpp
+++ b/libs/pure3d/pddi/gl/display_sgi/gldisplay.hpp
@@ -43,8 +43,6 @@ public:
     void SetContext(pglContext* c) {context = c;}
     bool ExtBGRA(void) { return extBGRA;}
 
-    static unsigned FillDisplayModes(pddiModeInfo*);
-
 private:
     pddiDisplayMode mode;
     int winWidth;

--- a/libs/pure3d/pddi/gl/display_vita/gldisplay.cpp
+++ b/libs/pure3d/pddi/gl/display_vita/gldisplay.cpp
@@ -42,14 +42,20 @@ pglDisplay ::pglDisplay(pddiDisplayInfo* info)
 pglDisplay ::~pglDisplay()
 {
     /* release and free the device context and rendering context */
+#if SDL_MAJOR_VERSION < 3
+    SDL_GL_DeleteContext(hRC);
     SDL_SetWindowGammaRamp(win, initialGammaRamp[0], initialGammaRamp[1], initialGammaRamp[2]);
+#else
+    SDL_GL_DestroyContext((SDL_GLContext)hRC);
+#endif
 }
 
 #define KEYPRESSED(x) (GetKeyState((x)) & (1<<(sizeof(int)*8)-1))
 
 long pglDisplay ::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* event)
 {
-    switch (event->event)
+#if SDL_MAJOR_VERSION < 3
+    switch(event->event)
     {
         case SDL_WINDOWEVENT_SIZE_CHANGED:
             SDL_GL_GetDrawableSize( win, &winWidth, &winHeight );
@@ -57,14 +63,31 @@ long pglDisplay ::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* e
 
         case SDL_WINDOWEVENT_CLOSE:
             /* release and free the device context and rendering context */
+            SDL_GL_DeleteContext(hRC);
             break;
 
 		default:
             return 0;
-     }
-     /* return 1 if handled message, 0 if not */
+    }
+#else
+    switch(event->type)
+    {
+        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+            SDL_GetWindowSizeInPixels( win, &winWidth, &winHeight );
+            break;
 
-     return 1;
+        case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+            /* release and free the device context and rendering context */
+            SDL_GL_DestroyContext((SDL_GLContext)hRC);
+            break;
+
+        default:
+            return 0;
+    }
+#endif
+
+    /* return 1 if handled message, 0 if not */
+    return 1;
 }
 
 
@@ -173,7 +196,9 @@ void pglDisplay::SetGamma(float r, float g, float b)
         gamma[2][i] =  (Uint16)(65535.0 * ((1.0 < gcb) ? 1.0 : gcb));
     }
 
+#if SDL_MAJOR_VERSION < 3
     SDL_SetWindowGammaRamp(win, gamma[0], gamma[1], gamma[2]);
+#endif
 }
 
 void pglDisplay::SwapBuffers(void)
@@ -190,27 +215,6 @@ unsigned pglDisplay::Screenshot(pddiColour* buffer, int nBytes)
     return 0;
 }
 
-unsigned pglDisplay::FillDisplayModes(int displayIndex, pddiModeInfo* displayModes)
-{
-    int nModes = 0;
-
-    SDL_DisplayMode devMode;
-
-    for (int i = 0; i < SDL_GetNumDisplayModes(displayIndex); i++)
-    {
-        if(SDL_GetDisplayMode(displayIndex, i, &devMode) == 0)
-        {
-            displayModes[nModes].width = devMode.w;
-            displayModes[nModes].height = devMode.h;
-            displayModes[nModes].bpp = 32;
-            nModes++;
-        }
-    }
-
-    return nModes;
-}
-    
-  
 void pglDisplay::BeginTiming()
 {
     beginTime = (float)SDL_GetTicks();

--- a/libs/pure3d/pddi/gl/display_win32/gldisplay.cpp
+++ b/libs/pure3d/pddi/gl/display_win32/gldisplay.cpp
@@ -45,15 +45,20 @@ pglDisplay ::pglDisplay(pddiDisplayInfo* info)
 pglDisplay ::~pglDisplay()
 {
     /* release and free the device context and rendering context */
+#if SDL_MAJOR_VERSION < 3
     SDL_GL_DeleteContext(hRC);
     SDL_SetWindowGammaRamp(win, initialGammaRamp[0], initialGammaRamp[1], initialGammaRamp[2]);
+#else
+    SDL_GL_DestroyContext((SDL_GLContext)hRC);
+#endif
 }
 
 #define KEYPRESSED(x) (GetKeyState((x)) & (1<<(sizeof(int)*8)-1))
 
 long pglDisplay ::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* event)
 {
-    switch (event->event)
+#if SDL_MAJOR_VERSION < 3
+    switch(event->event)
     {
         case SDL_WINDOWEVENT_SIZE_CHANGED:
             SDL_GL_GetDrawableSize( win, &winWidth, &winHeight );
@@ -66,10 +71,26 @@ long pglDisplay ::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* e
 
 		default:
             return 0;
-     }
-     /* return 1 if handled message, 0 if not */
+    }
+#else
+    switch(event->type)
+    {
+        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+            SDL_GetWindowSizeInPixels( win, &winWidth, &winHeight );
+            break;
 
-     return 1;
+        case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+            /* release and free the device context and rendering context */
+            SDL_GL_DestroyContext((SDL_GLContext)hRC);
+            break;
+
+        default:
+            return 0;
+    }
+#endif
+
+    /* return 1 if handled message, 0 if not */
+    return 1;
 }
 
 
@@ -307,7 +328,9 @@ void pglDisplay::SetGamma(float r, float g, float b)
         gamma[2][i] =  (Uint16)(65535.0 * ((1.0 < gcb) ? 1.0 : gcb));
     }
 
+#if SDL_MAJOR_VERSION < 3
     SDL_SetWindowGammaRamp(win, gamma[0], gamma[1], gamma[2]);
+#endif
 }
 
 void pglDisplay::SwapBuffers(void)
@@ -345,27 +368,6 @@ unsigned pglDisplay::Screenshot(pddiColour* buffer, int nBytes)
     return winHeight * winWidth * 4;
 }
 
-unsigned pglDisplay::FillDisplayModes(int displayIndex, pddiModeInfo* displayModes)
-{
-    int nModes = 0;
-
-    SDL_DisplayMode devMode;
-
-    for (int i = 0; i < SDL_GetNumDisplayModes(displayIndex); i++)
-    {
-        if(SDL_GetDisplayMode(displayIndex, i, &devMode) == 0)
-        {
-            displayModes[nModes].width = devMode.w;
-            displayModes[nModes].height = devMode.h;
-            displayModes[nModes].bpp = 32;
-            nModes++;
-        }
-    }
-
-    return nModes;
-}
-    
-  
 void pglDisplay::BeginTiming()
 {
     beginTime = (float)SDL_GetTicks();

--- a/libs/pure3d/pddi/gl/gldev.cpp
+++ b/libs/pure3d/pddi/gl/gldev.cpp
@@ -76,29 +76,69 @@ int pglDevice::GetDisplayInfo(pddiDisplayInfo** info)
         return nDisplays;
     }
 
+#if SDL_MAJOR_VERSION < 3
     int totalDisplay = SDL_GetNumVideoDisplays();
+#else
+    int totalDisplay;
+    SDL_DisplayID* displayIds = SDL_GetDisplays(&totalDisplay);
+#endif
     displayInfo = new pddiDisplayInfo[totalDisplay];
 
     nDisplays = 0;
     for(int i = 0; i < totalDisplay; i++)
     {
+#if SDL_MAJOR_VERSION < 3
+        SDL_DisplayMode devMode;
         const char* displayName = SDL_GetDisplayName(i);
         int totalModes = SDL_GetNumDisplayModes(i);
         if (!displayName || totalModes <= 0)
             continue;
+#else
+        const char* displayName = SDL_GetDisplayName(displayIds[i]);
+        int totalModes;
+        SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(displayIds[i], &totalModes);
+        if (!displayName || !modes)
+            continue;
+#endif
 
         displayInfo[nDisplays].id = i;
-        strcpy(displayInfo[0].description,SDL_GetDisplayName(i));
+        strcpy(displayInfo[0].description, displayName);
         displayInfo[nDisplays].pci = 0;
         displayInfo[nDisplays].vendor = 0;
         displayInfo[nDisplays].fullscreenOnly = false;
         displayInfo[nDisplays].caps = 0;
 
-        displayInfo[nDisplays].modeInfo = new pddiModeInfo[totalModes];
-        displayInfo[nDisplays].nDisplayModes = pglDisplay::FillDisplayModes(i, displayInfo[nDisplays].modeInfo);
-        displayInfo[nDisplays].modeInfo = displayInfo[nDisplays].modeInfo;
+        int nModes = 0;
+        pddiModeInfo* displayModes = new pddiModeInfo[totalModes];
+#if SDL_MAJOR_VERSION < 3
+        for(int j = 0; j < totalModes; j++)
+        {
+            if(SDL_GetDisplayMode(j, j, &devMode) == 0)
+            {
+                displayModes[nModes].width = devMode.w;
+                displayModes[nModes].height = devMode.h;
+                displayModes[nModes].bpp = 32;
+                nModes++;
+            }
+        }
+#else
+        for(int j = 0; j < totalModes; j++)
+        {
+            displayModes[nModes].width = modes[j]->w;
+            displayModes[nModes].height = modes[j]->h;
+            displayModes[nModes].bpp = 32;
+            nModes++;
+        }
+        SDL_free(modes);
+#endif
+
+        displayInfo[nDisplays].modeInfo = displayModes;
+        displayInfo[nDisplays].nDisplayModes = nModes;
         nDisplays++;
     }
+#if SDL_MAJOR_VERSION > 2
+    SDL_free(displayIds);
+#endif
 
     return nDisplays;
 }

--- a/libs/pure3d/pddi/gl/gldisplay.hpp
+++ b/libs/pure3d/pddi/gl/gldisplay.hpp
@@ -53,8 +53,6 @@ public:
     bool CheckExtension(const char*);
     bool HasReset(void) { return reset; }
 
-    static unsigned FillDisplayModes(int, pddiModeInfo*);
-
     void BeginContext(void);
     void EndContext(void);
 

--- a/libs/pure3d/pddi/gles/display_linux/gldisplay.cpp
+++ b/libs/pure3d/pddi/gles/display_linux/gldisplay.cpp
@@ -170,14 +170,6 @@ unsigned pglDisplay::Screenshot(pddiColour* buffer, int nBytes)
     // not implemented under linux
     assert(0 && "PDDI: pddiDisplay::ScreenShot() - Not implemented under linux.");
 }
-
-unsigned pglDisplay::FillDisplayModes(pddiModeInfo* displayModes)
-{
-    int i = 0;
-    int nModes = 0;
-
-    return nModes;
-}
     
 void pglDisplay::BeginTiming()
 {

--- a/libs/pure3d/pddi/gles/display_linux/gldisplay.hpp
+++ b/libs/pure3d/pddi/gles/display_linux/gldisplay.hpp
@@ -57,8 +57,6 @@ public:
     bool CheckExtension(char*);
     bool HasReset(void) { return reset; }
 
-    static unsigned FillDisplayModes(pddiModeInfo*);
-
     void BeginContext(void);
     void EndContext(void);
 

--- a/libs/pure3d/pddi/gles/display_sgi/gldisplay.cpp
+++ b/libs/pure3d/pddi/gles/display_sgi/gldisplay.cpp
@@ -291,14 +291,3 @@ pddiLockInfo*  pglSurface::Lock(pddiLockType l)
 void pglSurface::Unlock()
 {
 }
-
-unsigned pglDisplay::FillDisplayModes(pddiModeInfo* displayModes)
-{
-    int i = 0;
-    int nModes = 0;
-
-    return nModes;
-}
-    
-
-

--- a/libs/pure3d/pddi/gles/display_sgi/gldisplay.hpp
+++ b/libs/pure3d/pddi/gles/display_sgi/gldisplay.hpp
@@ -43,8 +43,6 @@ public:
     void SetContext(pglContext* c) {context = c;}
     bool ExtBGRA(void) { return extBGRA;}
 
-    static unsigned FillDisplayModes(pddiModeInfo*);
-
 private:
     pddiDisplayMode mode;
     int winWidth;

--- a/libs/pure3d/pddi/gles/display_vita/gldisplay.cpp
+++ b/libs/pure3d/pddi/gles/display_vita/gldisplay.cpp
@@ -42,14 +42,20 @@ pglDisplay ::pglDisplay(pddiDisplayInfo* info)
 pglDisplay ::~pglDisplay()
 {
     /* release and free the device context and rendering context */
+#if SDL_MAJOR_VERSION < 3
+    SDL_GL_DeleteContext(hRC);
     SDL_SetWindowGammaRamp(win, initialGammaRamp[0], initialGammaRamp[1], initialGammaRamp[2]);
+#else
+    SDL_GL_DestroyContext((SDL_GLContext)hRC);
+#endif
 }
 
 #define KEYPRESSED(x) (GetKeyState((x)) & (1<<(sizeof(int)*8)-1))
 
 long pglDisplay ::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* event)
 {
-    switch (event->event)
+#if SDL_MAJOR_VERSION < 3
+    switch(event->event)
     {
         case SDL_WINDOWEVENT_SIZE_CHANGED:
             SDL_GL_GetDrawableSize( win, &winWidth, &winHeight );
@@ -57,20 +63,39 @@ long pglDisplay ::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* e
 
         case SDL_WINDOWEVENT_CLOSE:
             /* release and free the device context and rendering context */
+            SDL_GL_DeleteContext(hRC);
             break;
 
 		default:
             return 0;
-     }
-     /* return 1 if handled message, 0 if not */
+    }
+#else
+    switch(event->type)
+    {
+        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+            SDL_GetWindowSizeInPixels( win, &winWidth, &winHeight );
+            break;
 
-     return 1;
+        case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+            /* release and free the device context and rendering context */
+            SDL_GL_DestroyContext((SDL_GLContext)hRC);
+            break;
+
+        default:
+            return 0;
+    }
+#endif
+
+    /* return 1 if handled message, 0 if not */
+    return 1;
 }
 
 
 void pglDisplay ::SetWindow(SDL_Window* wnd)
 {
+#if SDL_MAJOR_VERSION < 3
     SDL_GetWindowGammaRamp(wnd, initialGammaRamp[0], initialGammaRamp[1], initialGammaRamp[2]);
+#endif
     win = wnd;
 }
 
@@ -173,7 +198,9 @@ void pglDisplay::SetGamma(float r, float g, float b)
         gamma[2][i] =  (Uint16)(65535.0 * ((1.0 < gcb) ? 1.0 : gcb));
     }
 
+#if SDL_MAJOR_VERSION < 3
     SDL_SetWindowGammaRamp(win, gamma[0], gamma[1], gamma[2]);
+#endif
 }
 
 void pglDisplay::SwapBuffers(void)
@@ -188,26 +215,6 @@ unsigned pglDisplay::Screenshot(pddiColour* buffer, int nBytes)
     // not implemented under vita
     assert( 0 && "PDDI: pddiDisplay::ScreenShot() - Not implemented under vita." );
     return 0;
-}
-
-unsigned pglDisplay::FillDisplayModes(int displayIndex, pddiModeInfo* displayModes)
-{
-    int nModes = 0;
-
-    SDL_DisplayMode devMode;
-
-    for (int i = 0; i < SDL_GetNumDisplayModes(displayIndex); i++)
-    {
-        if(SDL_GetDisplayMode(displayIndex, i, &devMode) == 0)
-        {
-            displayModes[nModes].width = devMode.w;
-            displayModes[nModes].height = devMode.h;
-            displayModes[nModes].bpp = 32;
-            nModes++;
-        }
-    }
-
-    return nModes;
 }
 
 void pglDisplay::BeginTiming()

--- a/libs/pure3d/pddi/gles/display_win32/gldisplay.cpp
+++ b/libs/pure3d/pddi/gles/display_win32/gldisplay.cpp
@@ -14,7 +14,7 @@
 
 bool pglDisplay::CheckExtension( const char *extName )
 {
-    return SDL_GL_ExtensionSupported(extName) == SDL_TRUE;
+    return SDL_GL_ExtensionSupported(extName);
 }
 
 pglDisplay ::pglDisplay(pddiDisplayInfo* info)
@@ -42,15 +42,20 @@ pglDisplay ::pglDisplay(pddiDisplayInfo* info)
 pglDisplay ::~pglDisplay()
 {
     /* release and free the device context and rendering context */
+#if SDL_MAJOR_VERSION < 3
     SDL_GL_DeleteContext(hRC);
     SDL_SetWindowGammaRamp(win, initialGammaRamp[0], initialGammaRamp[1], initialGammaRamp[2]);
+#else
+    SDL_GL_DestroyContext((SDL_GLContext)hRC);
+#endif
 }
 
 #define KEYPRESSED(x) (GetKeyState((x)) & (1<<(sizeof(int)*8)-1))
 
 long pglDisplay ::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* event)
 {
-    switch (event->event)
+#if SDL_MAJOR_VERSION < 3
+    switch(event->event)
     {
         case SDL_WINDOWEVENT_SIZE_CHANGED:
             SDL_GL_GetDrawableSize( win, &winWidth, &winHeight );
@@ -63,16 +68,34 @@ long pglDisplay ::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* e
 
 		default:
             return 0;
-     }
-     /* return 1 if handled message, 0 if not */
+    }
+#else
+    switch(event->type)
+    {
+        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+            SDL_GetWindowSizeInPixels( win, &winWidth, &winHeight );
+            break;
 
-     return 1;
+        case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+            /* release and free the device context and rendering context */
+            SDL_GL_DestroyContext((SDL_GLContext)hRC);
+            break;
+
+        default:
+            return 0;
+    }
+#endif
+
+    /* return 1 if handled message, 0 if not */
+    return 1;
 }
 
 
 void pglDisplay ::SetWindow(SDL_Window* wnd)
 {
+#if SDL_MAJOR_VERSION < 3
     SDL_GetWindowGammaRamp(wnd, initialGammaRamp[0], initialGammaRamp[1], initialGammaRamp[2]);
+#endif
     win = wnd;
 }
 
@@ -139,14 +162,23 @@ bool pglDisplay ::InitDisplay(const pddiDisplayInit* init)
     SDL_DisplayMode displayMode = {}, closestMode = {};
     displayMode.w = x;
     displayMode.h = y;
+#if SDL_MAJOR_VERSION < 3
     SDL_DisplayMode* pDisplayMode = SDL_GetClosestDisplayMode(displayInfo->id, &displayMode, &closestMode);
     if (pDisplayMode)
         SDL_SetWindowDisplayMode(win, pDisplayMode);
+#else
+    if(SDL_GetClosestFullscreenDisplayMode((SDL_DisplayID)displayInfo->id, x, y, 0.0f, false, &closestMode))
+        SDL_SetWindowFullscreenMode(win, &closestMode);
+#endif
 
 #ifndef __SWITCH__
     SDL_SetWindowFullscreen(win, mode == PDDI_DISPLAY_FULLSCREEN ? SDL_WINDOW_FULLSCREEN : 0);
 #endif
+#if SDL_MAJOR_VERSION < 3
     SDL_GL_GetDrawableSize( win, &winWidth, &winHeight );
+#else
+    SDL_GetWindowSizeInPixels( win, &winWidth, &winHeight );
+#endif
     winBitDepth = bpp;
 
     if (hRC)
@@ -168,7 +200,7 @@ bool pglDisplay ::InitDisplay(const pddiDisplayInit* init)
     else
         SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
 #ifndef RAD_VITA
-    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, SDL_TRUE);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, true);
 #ifdef RAD_DEBUG
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 #endif
@@ -301,7 +333,9 @@ void pglDisplay::SetGamma(float r, float g, float b)
         gamma[2][i] =  (Uint16)(65535.0 * ((1.0 < gcb) ? 1.0 : gcb));
     }
 
+#if SDL_MAJOR_VERSION < 3
     SDL_SetWindowGammaRamp(win, gamma[0], gamma[1], gamma[2]);
+#endif
 }
 
 void pglDisplay::SwapBuffers(void)
@@ -333,26 +367,6 @@ unsigned pglDisplay::Screenshot(pddiColour* buffer, int nBytes)
     return winHeight * winWidth * 4;
 }
 
-unsigned pglDisplay::FillDisplayModes(int displayIndex, pddiModeInfo* displayModes)
-{
-    int nModes = 0;
-
-    SDL_DisplayMode devMode;
-
-    for (int i = 0; i < SDL_GetNumDisplayModes(displayIndex); i++)
-    {
-        if(SDL_GetDisplayMode(displayIndex, i, &devMode) == 0)
-        {
-            displayModes[nModes].width = devMode.w;
-            displayModes[nModes].height = devMode.h;
-            displayModes[nModes].bpp = 32;
-            nModes++;
-        }
-    }
-
-    return nModes;
-}
-
 void pglDisplay::BeginTiming()
 {
     beginTime = (float)SDL_GetTicks();
@@ -367,13 +381,13 @@ void pglDisplay::BeginContext(void)
 {
     prevRC = SDL_GL_GetCurrentContext();
     PDDIASSERT(prevRC != hRC);
-    int error = SDL_GL_MakeCurrent(win, hRC);
+    int error = SDL_GL_MakeCurrent(win, (SDL_GLContext)hRC);
     PDDIASSERT(!error);
 }
 
 void pglDisplay::EndContext(void)
 {
-    int error = SDL_GL_MakeCurrent(win, prevRC);
+    int error = SDL_GL_MakeCurrent(win, (SDL_GLContext)prevRC);
     PDDIASSERT(!error);
 }
 

--- a/libs/pure3d/pddi/gles/gldev.cpp
+++ b/libs/pure3d/pddi/gles/gldev.cpp
@@ -76,29 +76,69 @@ int pglDevice::GetDisplayInfo(pddiDisplayInfo** info)
         return nDisplays;
     }
 
+#if SDL_MAJOR_VERSION < 3
     int totalDisplay = SDL_GetNumVideoDisplays();
+#else
+    int totalDisplay;
+    SDL_DisplayID* displayIds = SDL_GetDisplays(&totalDisplay);
+#endif
     displayInfo = new pddiDisplayInfo[totalDisplay];
 
     nDisplays = 0;
     for(int i = 0; i < totalDisplay; i++)
     {
+#if SDL_MAJOR_VERSION < 3
+        SDL_DisplayMode devMode;
         const char* displayName = SDL_GetDisplayName(i);
         int totalModes = SDL_GetNumDisplayModes(i);
         if (!displayName || totalModes <= 0)
             continue;
+#else
+        const char* displayName = SDL_GetDisplayName(displayIds[i]);
+        int totalModes;
+        SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(displayIds[i], &totalModes);
+        if (!displayName || !modes)
+            continue;
+#endif
 
         displayInfo[nDisplays].id = i;
-        strcpy(displayInfo[0].description,SDL_GetDisplayName(i));
+        strcpy(displayInfo[0].description, displayName);
         displayInfo[nDisplays].pci = 0;
         displayInfo[nDisplays].vendor = 0;
         displayInfo[nDisplays].fullscreenOnly = false;
         displayInfo[nDisplays].caps = 0;
 
-        displayInfo[nDisplays].modeInfo = new pddiModeInfo[totalModes];
-        displayInfo[nDisplays].nDisplayModes = pglDisplay::FillDisplayModes(i, displayInfo[nDisplays].modeInfo);
-        displayInfo[nDisplays].modeInfo = displayInfo[nDisplays].modeInfo;
+        int nModes = 0;
+        pddiModeInfo* displayModes = new pddiModeInfo[totalModes];
+#if SDL_MAJOR_VERSION < 3
+        for(int j = 0; j < totalModes; j++)
+        {
+            if(SDL_GetDisplayMode(j, j, &devMode) == 0)
+            {
+                displayModes[nModes].width = devMode.w;
+                displayModes[nModes].height = devMode.h;
+                displayModes[nModes].bpp = 32;
+                nModes++;
+            }
+        }
+#else
+        for(int j = 0; j < totalModes; j++)
+        {
+            displayModes[nModes].width = modes[j]->w;
+            displayModes[nModes].height = modes[j]->h;
+            displayModes[nModes].bpp = 32;
+            nModes++;
+        }
+        SDL_free(modes);
+#endif
+
+        displayInfo[nDisplays].modeInfo = displayModes;
+        displayInfo[nDisplays].nDisplayModes = nModes;
         nDisplays++;
     }
+#if SDL_MAJOR_VERSION > 2
+    SDL_free(displayIds);
+#endif
 
     return nDisplays;
 }

--- a/libs/pure3d/pddi/gles/gldisplay.hpp
+++ b/libs/pure3d/pddi/gles/gldisplay.hpp
@@ -50,8 +50,6 @@ public:
     bool CheckExtension(const char*);
     bool HasReset(void) { return reset; }
 
-    static unsigned FillDisplayModes(int, pddiModeInfo*);
-
     void BeginContext(void);
     void EndContext(void);
 

--- a/libs/pure3d/pddi/gxm/device.cpp
+++ b/libs/pure3d/pddi/gxm/device.cpp
@@ -26,7 +26,7 @@ static gxmDevice gblDevice;
 char libName [] = "GXM";
 
 #ifdef PDDI_USE_ASSERTS
-
+#include <raddebug.hpp>
 const char* pddiGxmErrorString(unsigned int err)
 {
     switch(err)
@@ -127,29 +127,69 @@ int gxmDevice::GetDisplayInfo(pddiDisplayInfo** info)
         return nDisplays;
     }
 
+#if SDL_MAJOR_VERSION < 3
     int totalDisplay = SDL_GetNumVideoDisplays();
+#else
+    int totalDisplay;
+    SDL_DisplayID* displayIds = SDL_GetDisplays(&totalDisplay);
+#endif
     displayInfo = new pddiDisplayInfo[totalDisplay];
 
     nDisplays = 0;
     for(int i = 0; i < totalDisplay; i++)
     {
+#if SDL_MAJOR_VERSION < 3
+        SDL_DisplayMode devMode;
         const char* displayName = SDL_GetDisplayName(i);
         int totalModes = SDL_GetNumDisplayModes(i);
         if (!displayName || totalModes <= 0)
             continue;
+#else
+        const char* displayName = SDL_GetDisplayName(displayIds[i]);
+        int totalModes;
+        SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(displayIds[i], &totalModes);
+        if (!displayName || !modes)
+            continue;
+#endif
 
         displayInfo[nDisplays].id = i;
-        strcpy(displayInfo[0].description,SDL_GetDisplayName(i));
+        strcpy(displayInfo[0].description, displayName);
         displayInfo[nDisplays].pci = 0;
         displayInfo[nDisplays].vendor = 0;
         displayInfo[nDisplays].fullscreenOnly = false;
         displayInfo[nDisplays].caps = 0;
 
-        displayInfo[nDisplays].modeInfo = new pddiModeInfo[totalModes];
-        displayInfo[nDisplays].nDisplayModes = gxmDisplay::FillDisplayModes(i, displayInfo[nDisplays].modeInfo);
-        displayInfo[nDisplays].modeInfo = displayInfo[nDisplays].modeInfo;
+        int nModes = 0;
+        pddiModeInfo* displayModes = new pddiModeInfo[totalModes];
+#if SDL_MAJOR_VERSION < 3
+        for(int j = 0; j < totalModes; j++)
+        {
+            if(SDL_GetDisplayMode(j, j, &devMode) == 0)
+            {
+                displayModes[nModes].width = devMode.w;
+                displayModes[nModes].height = devMode.h;
+                displayModes[nModes].bpp = 32;
+                nModes++;
+            }
+        }
+#else
+        for(int j = 0; j < totalModes; j++)
+        {
+            displayModes[nModes].width = modes[j]->w;
+            displayModes[nModes].height = modes[j]->h;
+            displayModes[nModes].bpp = 32;
+            nModes++;
+        }
+        SDL_free(modes);
+#endif
+
+        displayInfo[nDisplays].modeInfo = displayModes;
+        displayInfo[nDisplays].nDisplayModes = nModes;
         nDisplays++;
     }
+#if SDL_MAJOR_VERSION > 2
+    SDL_free(displayIds);
+#endif
 
     return nDisplays;
 }

--- a/libs/pure3d/pddi/gxm/display.cpp
+++ b/libs/pure3d/pddi/gxm/display.cpp
@@ -74,14 +74,17 @@ gxmDisplay::~gxmDisplay()
     free(contextParams.hostMem);
     sceGxmTerminate();
 
+#if SDL_MAJOR_VERSION < 3
     SDL_SetWindowGammaRamp(win, initialGammaRamp[0], initialGammaRamp[1], initialGammaRamp[2]);
+#endif
 }
 
 #define KEYPRESSED(x) (GetKeyState((x)) & (1<<(sizeof(int)*8)-1))
 
 long gxmDisplay::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* event)
 {
-    switch (event->event)
+#if SDL_MAJOR_VERSION < 3
+    switch(event->event)
     {
         case SDL_WINDOWEVENT_SIZE_CHANGED:
             SDL_GL_GetDrawableSize( win, &winWidth, &winHeight );
@@ -93,16 +96,33 @@ long gxmDisplay::ProcessWindowMessage(SDL_Window* win, const SDL_WindowEvent* ev
 
 		default:
             return 0;
-     }
-     /* return 1 if handled message, 0 if not */
+    }
+#else
+    switch(event->type)
+    {
+        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+            SDL_GetWindowSizeInPixels( win, &winWidth, &winHeight );
+            break;
 
-     return 1;
+        case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+            /* release and free the device context and rendering context */
+            break;
+
+        default:
+            return 0;
+    }
+#endif
+
+    /* return 1 if handled message, 0 if not */
+    return 1;
 }
 
 
 void gxmDisplay::SetWindow(SDL_Window* wnd)
 {
+#if SDL_MAJOR_VERSION < 3
     SDL_GetWindowGammaRamp( wnd, initialGammaRamp[0], initialGammaRamp[1], initialGammaRamp[2] );
+#endif
     win = wnd;
 }
 
@@ -369,7 +389,9 @@ void gxmDisplay::SetGamma(float r, float g, float b)
         gamma[2][i] = (Uint16)(65535.0 * ((1.0 < gcb) ? 1.0 : gcb));
     }
 
+#if SDL_MAJOR_VERSION < 3
     SDL_SetWindowGammaRamp(win, gamma[0], gamma[1], gamma[2]);
+#endif
 }
 
 void gxmDisplay::SwapBuffers(void)
@@ -397,26 +419,6 @@ unsigned gxmDisplay::Screenshot(pddiColour* buffer, int nBytes)
     // not implemented under vita
     assert( 0 && "PDDI: pddiDisplay::ScreenShot() - Not implemented under vita." );
     return 0;
-}
-
-unsigned gxmDisplay::FillDisplayModes(int displayIndex, pddiModeInfo* displayModes)
-{
-    int nModes = 0;
-
-    SDL_DisplayMode devMode;
-
-    for (int i = 0; i < SDL_GetNumDisplayModes(displayIndex); i++)
-    {
-        if(SDL_GetDisplayMode(displayIndex, i, &devMode) == 0)
-        {
-            displayModes[nModes].width = devMode.w;
-            displayModes[nModes].height = devMode.h;
-            displayModes[nModes].bpp = 32;
-            nModes++;
-        }
-    }
-
-    return nModes;
 }
 
 void gxmDisplay::BeginTiming()

--- a/libs/pure3d/pddi/gxm/display.hpp
+++ b/libs/pure3d/pddi/gxm/display.hpp
@@ -61,8 +61,6 @@ public:
     bool CheckExtension(const char*);
     bool HasReset(void) { return reset; }
 
-    static unsigned FillDisplayModes(int, pddiModeInfo*);
-
     void SetGamma(float r, float g, float b);
     void GetGamma(float* r, float* g, float* b);
 

--- a/libs/radcore/src/radcontroller/sdlcontroller.cpp
+++ b/libs/radcore/src/radcontroller/sdlcontroller.cpp
@@ -80,6 +80,7 @@ static const char * g_Sdlipt[] =
 
 static SDLInputPoint g_SDLPoints[] =
 {
+#if SDL_MAJOR_VERSION < 3
     { g_Sdlipt[ 0 ], "DPadUp",           SDL_CONTROLLER_BUTTON_DPAD_UP },
     { g_Sdlipt[ 0 ], "DPadDown",         SDL_CONTROLLER_BUTTON_DPAD_DOWN },
     { g_Sdlipt[ 0 ], "DPadLeft",         SDL_CONTROLLER_BUTTON_DPAD_LEFT },
@@ -107,6 +108,35 @@ static SDLInputPoint g_SDLPoints[] =
     { g_Sdlipt[ 3 ], "LeftStickY",       SDL_CONTROLLER_AXIS_LEFTY },
     { g_Sdlipt[ 2 ], "RightStickX",      SDL_CONTROLLER_AXIS_RIGHTX },
     { g_Sdlipt[ 3 ], "RightStickY",      SDL_CONTROLLER_AXIS_RIGHTY }
+#else
+    { g_Sdlipt[ 0 ], "DPadUp",           SDL_GAMEPAD_BUTTON_DPAD_UP },
+    { g_Sdlipt[ 0 ], "DPadDown",         SDL_GAMEPAD_BUTTON_DPAD_DOWN },
+    { g_Sdlipt[ 0 ], "DPadLeft",         SDL_GAMEPAD_BUTTON_DPAD_LEFT },
+    { g_Sdlipt[ 0 ], "DPadRight",        SDL_GAMEPAD_BUTTON_DPAD_RIGHT },
+    { g_Sdlipt[ 0 ], "Start",            SDL_GAMEPAD_BUTTON_START },
+    { g_Sdlipt[ 0 ], "Back",             SDL_GAMEPAD_BUTTON_BACK },
+    { g_Sdlipt[ 0 ], "LeftThumb",        SDL_GAMEPAD_BUTTON_LEFT_STICK },
+    { g_Sdlipt[ 0 ], "RightThumb",       SDL_GAMEPAD_BUTTON_RIGHT_STICK },
+#ifdef __SWITCH__
+    { g_Sdlipt[ 0 ], "A",                SDL_GAMEPAD_BUTTON_EAST },
+    { g_Sdlipt[ 0 ], "B",                SDL_GAMEPAD_BUTTON_SOUTH },
+    { g_Sdlipt[ 0 ], "X",                SDL_GAMEPAD_BUTTON_NORTH },
+    { g_Sdlipt[ 0 ], "Y",                SDL_GAMEPAD_BUTTON_WEST },
+#else
+    { g_Sdlipt[ 0 ], "A",                SDL_GAMEPAD_BUTTON_SOUTH },
+    { g_Sdlipt[ 0 ], "B",                SDL_GAMEPAD_BUTTON_EAST },
+    { g_Sdlipt[ 0 ], "X",                SDL_GAMEPAD_BUTTON_WEST },
+    { g_Sdlipt[ 0 ], "Y",                SDL_GAMEPAD_BUTTON_NORTH },
+#endif
+    { g_Sdlipt[ 0 ], "Black",            SDL_GAMEPAD_BUTTON_LEFT_SHOULDER },
+    { g_Sdlipt[ 0 ], "White",            SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER },
+    { g_Sdlipt[ 1 ], "LeftTrigger",      SDL_GAMEPAD_AXIS_LEFT_TRIGGER },
+    { g_Sdlipt[ 1 ], "RightTrigger",     SDL_GAMEPAD_AXIS_RIGHT_TRIGGER },
+    { g_Sdlipt[ 2 ], "LeftStickX",       SDL_GAMEPAD_AXIS_LEFTX },
+    { g_Sdlipt[ 3 ], "LeftStickY",       SDL_GAMEPAD_AXIS_LEFTY },
+    { g_Sdlipt[ 2 ], "RightStickX",      SDL_GAMEPAD_AXIS_RIGHTX },
+    { g_Sdlipt[ 3 ], "RightStickY",      SDL_GAMEPAD_AXIS_RIGHTY }
+#endif
 };
 
 static class radControllerSystemSDL* s_pTheSDLControllerSystem2 = NULL;
@@ -252,16 +282,28 @@ class radControllerInputPointSDL
         {
             if ( m_pType == g_Sdlipt[ 0 ] ) // Button
             {
+#if SDL_MAJOR_VERSION < 3
                 newValue = SDL_GameControllerGetButton( m_pController, (SDL_GameControllerButton)m_Identifier ) ? 1.0f : 0.0f;
+#else
+                newValue = SDL_GetGamepadButton( m_pController, (SDL_GamepadButton)m_Identifier ) ? 1.0f : 0.0f;
+#endif
             }
             else if ( m_pType == g_Sdlipt[ 1 ] ) // Analog Button
             {
+#if SDL_MAJOR_VERSION < 3
                 newValue = SDL_GameControllerGetAxis( m_pController, (SDL_GameControllerAxis)m_Identifier );
+#else
+                newValue = SDL_GetGamepadAxis( m_pController, (SDL_GamepadAxis)m_Identifier );
+#endif
                 newValue /= 32767.0f;
             }
             else if ( ( m_pType == g_Sdlipt[ 2 ] ) || ( m_pType == g_Sdlipt[ 3 ] ) ) // X/Y Axis
             {
+#if SDL_MAJOR_VERSION < 3
                 newValue = SDL_GameControllerGetAxis( m_pController, (SDL_GameControllerAxis)m_Identifier );
+#else
+                newValue = SDL_GetGamepadAxis( m_pController, (SDL_GamepadAxis)m_Identifier );
+#endif
                 if ( newValue > 0.0f )
                 {
                     newValue /= 65534.0f;
@@ -273,7 +315,11 @@ class radControllerInputPointSDL
 
                 newValue += 0.5f;
 
+#if SDL_MAJOR_VERSION < 3
                 if ( m_Identifier == SDL_CONTROLLER_AXIS_LEFTY || m_Identifier == SDL_CONTROLLER_AXIS_RIGHTY )
+#else
+                if ( m_Identifier == SDL_GAMEPAD_AXIS_LEFTY || m_Identifier == SDL_GAMEPAD_AXIS_RIGHTY )
+#endif
                 {
                     newValue = 1.0f - newValue;
                 }
@@ -545,8 +591,11 @@ class radControllerInputPointSDL
     //========================================================================
     // radControllerInputPointSDL::radControllerInputPointSDL
     //========================================================================
-
+#if SDL_MAJOR_VERSION < 3
     radControllerInputPointSDL( SDL_GameController * pController, const char * pType, const char * pName, int id )
+#else
+    radControllerInputPointSDL( SDL_Gamepad * pController, const char * pType, const char * pName, int id )
+#endif
         :
         radRefCount( 0 ),
         m_Value( 0.0f ),
@@ -594,7 +643,11 @@ class radControllerInputPointSDL
     const char * m_pName;
 
     int m_Identifier;
+#if SDL_MAJOR_VERSION < 3
     SDL_GameController * m_pController;
+#else
+    SDL_Gamepad * m_pController;
+#endif
 
     ref< IRadObjectList > m_xIOl_Callbacks;
 };
@@ -628,7 +681,11 @@ class radControllerSDL
         {
             if ( m_pController != NULL )
             {
+#if SDL_MAJOR_VERSION < 3
                 SDL_GameControllerUpdate();
+#else
+                SDL_UpdateGamepads();
+#endif
             }
 
             //
@@ -656,8 +713,13 @@ class radControllerSDL
                     int result = 0;
 					if(m_pController != NULL)
 					{
+#if SDL_MAJOR_VERSION < 3
                         result = SDL_GameControllerRumble( m_pController,
                             m_LeftGain, m_RightGain, 0 );
+#else
+                        result = SDL_RumbleGamepad( m_pController,
+                            m_LeftGain, m_RightGain, 0 );
+#endif
 					}
 
                     //
@@ -732,7 +794,11 @@ class radControllerSDL
 
     virtual bool IsConnected( void )
     {
+#if SDL_MAJOR_VERSION < 3
         return SDL_GameControllerGetAttached( m_pController ) == SDL_TRUE;
+#else
+        return SDL_GamepadConnected( m_pController );
+#endif
     }
 
     //========================================================================
@@ -1019,7 +1085,11 @@ class radControllerSDL
     radControllerSDL
     (
         unsigned int thisAllocator,
-        SDL_GameController* pController,
+#if SDL_MAJOR_VERSION < 3
+        SDL_GameController * pController,
+#else
+        SDL_Gamepad * pController,
+#endif
         unsigned int virtualTime,
         unsigned int bufferTime,
         unsigned int pollingRate
@@ -1048,8 +1118,11 @@ class radControllerSDL
         //
         // Create our location name based on our port and slot
         //
-
+#if SDL_MAJOR_VERSION < 3
         int iController = std::max(SDL_GameControllerGetPlayerIndex( pController ), 0);
+#else
+        int iController = std::max(SDL_GetGamepadPlayerIndex( pController ), 0);
+#endif
 		m_xIString_Location->SetSize( 12 );
         m_xIString_Location->Append( "Port" );
         m_xIString_Location->Append( (unsigned int) iController );
@@ -1110,8 +1183,11 @@ class radControllerSDL
     //========================================================================
     // radControllerSDL Data Members
     //========================================================================
-
+#if SDL_MAJOR_VERSION < 3
     SDL_GameController *              m_pController;
+#else
+    SDL_Gamepad *                     m_pController;
+#endif
 
     ref< IRadObjectList >             m_xIOl_InputPoints;
     ref< IRadObjectList >             m_xIOl_OutputPoints;
@@ -1138,19 +1214,30 @@ class radControllerSystemSDL
      //========================================================================
     // radControllerSystemSDL::CheckDeviceConnectionStatus
     //========================================================================
-
+#if SDL_MAJOR_VERSION < 3
     static int CheckDeviceConnectionStatus( void * userdata, SDL_Event * event )
+#else
+    static bool CheckDeviceConnectionStatus( void * userdata, SDL_Event * event )
+#endif
     {
         //
         // Check if devices have been inserted or removed
         //
-        SDL_GameController* pController;
+#if SDL_MAJOR_VERSION < 3
+        SDL_GameController * pController;
         if( event->type == SDL_CONTROLLERDEVICEADDED )
             pController = SDL_GameControllerOpen( event->cdevice.which );
         else if( event->type == SDL_CONTROLLERDEVICEREMOVED )
             pController = SDL_GameControllerFromInstanceID( event->cdevice.which );
+#else
+        SDL_Gamepad * pController;
+        if( event->type == SDL_EVENT_GAMEPAD_ADDED )
+            pController = SDL_OpenGamepad( event->cdevice.which );
+        else if( event->type == SDL_EVENT_GAMEPAD_REMOVED )
+            pController = SDL_GetGamepadFromID( event->cdevice.which );
+#endif
         else
-            return 1;
+            return true;
 
         radControllerSystemSDL* sys = (radControllerSystemSDL*)userdata;
         sys->AddRef( );
@@ -1163,7 +1250,11 @@ class radControllerSystemSDL
 
         char location[255];
 
+#if SDL_MAJOR_VERSION < 3
         int iController = std::max( SDL_GameControllerGetPlayerIndex( pController ), 0 );
+#else
+        int iController = std::max( SDL_GetGamepadPlayerIndex( pController ), 0 );
+#endif
         sprintf( location, "Port%d\\Slot0", iController );
 
         xIController2 = sys->GetControllerAtLocation( location );
@@ -1174,7 +1265,11 @@ class radControllerSystemSDL
             rAssert( xISDLController2 != NULL );
         }
 
+#if SDL_MAJOR_VERSION < 3
         if( event->type == SDL_CONTROLLERDEVICEADDED )
+#else
+        if( event->type == SDL_EVENT_GAMEPAD_ADDED )
+#endif
         {
             //
             // Here a device has been inserted, so open it
@@ -1214,10 +1309,14 @@ class radControllerSystemSDL
             else
             {
                 sys->Release( );
-                return 0;
+                return false;
             }
         }
+#if SDL_MAJOR_VERSION < 3
         else if( event->type == SDL_CONTROLLERDEVICEREMOVED )
+#else
+        else if( event->type == SDL_EVENT_GAMEPAD_REMOVED )
+#endif
         {
 			//
             // Here a device has been removed
@@ -1242,7 +1341,7 @@ class radControllerSystemSDL
         }
 
         sys->Release( );
-        return 0;
+        return false;
     }
 
     //========================================================================
@@ -1568,9 +1667,19 @@ class radControllerSystemSDL
         //
         // TODO: If there is no connection change callback, wait synchronously for the connection
         //
-        for( int i = 0; i < SDL_NumJoysticks(); i++ )
+#if SDL_MAJOR_VERSION < 3
+        int numJoysticks = SDL_NumJoysticks();
+#else
+        int numJoysticks;
+        SDL_JoystickID* joysticks = SDL_GetJoysticks( &numJoysticks );
+#endif
+        for( int i = 0; i < numJoysticks; i++ )
         {
+#if SDL_MAJOR_VERSION < 3
             if( SDL_IsGameController( i ) )
+#else
+            if( SDL_IsGamepad( joysticks[i] ) )
+#endif
             {
                 ref< IRadController > xIController2;
                 unsigned int virtualTime = 0;
@@ -1586,7 +1695,11 @@ class radControllerSystemSDL
                 xIController2 = new (g_ControllerSystemAllocator) radControllerSDL
                 (
                     g_ControllerSystemAllocator,
+#if SDL_MAJOR_VERSION < 3
                     SDL_GameControllerOpen( i ),
+#else
+                    SDL_OpenGamepad( joysticks[i] ),
+#endif
                     virtualTime,
                     m_EventBufferTime,
                     pollingRate
@@ -1609,6 +1722,9 @@ class radControllerSystemSDL
                 }
             }
         }
+#if SDL_MAJOR_VERSION > 2
+        SDL_free( joysticks );
+#endif
 
         //
         // Set everything to know state
@@ -1691,7 +1807,11 @@ void radControllerInitialize
 
 void radControllerTerminate( void )
 {
+#if SDL_MAJOR_VERSION < 3
     SDL_DelEventWatch( radControllerSystemSDL::CheckDeviceConnectionStatus, s_pTheSDLControllerSystem2 );
+#else
+    SDL_RemoveEventWatch( radControllerSystemSDL::CheckDeviceConnectionStatus, s_pTheSDLControllerSystem2 );
+#endif
 
     radRelease( s_pTheSDLControllerSystem2, NULL );
 }

--- a/libs/radcore/src/raddispatch/dispatcher.cpp
+++ b/libs/radcore/src/raddispatch/dispatcher.cpp
@@ -29,6 +29,8 @@
 #include <raddebug.hpp>
 #include <radmemorymonitor.hpp>
 
+#include <SDL.h>
+
 #include "dispatcher.hpp"
 
 //=============================================================================
@@ -98,7 +100,7 @@ radDispatcher::radDispatcher
     //
     m_EventQueue = (Event*) radMemoryAlloc( alloc, sizeof(Event) * m_MaxEvents );
 
-    m_Mutex = SDL_CreateMutex();
+    m_Mutex = (SDL_Mutex*) SDL_CreateMutex();
 }
 
 //=============================================================================
@@ -119,8 +121,12 @@ radDispatcher::~radDispatcher( void )
     // If this asserts the caller did not call purge.
     //
     rAssert( m_EventsQueued == 0 );
-   
-    SDL_DestroyMutex(m_Mutex);
+
+#if SDL_MAJOR_VERSION < 3
+    SDL_DestroyMutex( (SDL_mutex*)m_Mutex );
+#else
+    SDL_DestroyMutex( m_Mutex );
+#endif
 
     //
     // Free up the memory
@@ -219,7 +225,11 @@ void radDispatcher::QueueCallback
 
     //
     // Protect the addition of this record to the event list.
-    SDL_LockMutex(m_Mutex);
+#if SDL_MAJOR_VERSION < 3
+    SDL_LockMutex( (SDL_mutex*)m_Mutex );
+#else
+    SDL_LockMutex( m_Mutex );
+#endif
 
     //
     // Assert that we have not exceeded the maximum number of events in the queue.
@@ -241,7 +251,11 @@ void radDispatcher::QueueCallback
     //
     // Remove protection
     //
-    SDL_UnlockMutex(m_Mutex);
+#if SDL_MAJOR_VERSION < 3
+    SDL_UnlockMutex( (SDL_mutex*)m_Mutex );
+#else
+    SDL_UnlockMutex( m_Mutex );
+#endif
 }
 
 
@@ -342,7 +356,11 @@ unsigned int radDispatcher::Service( void )
     // Protect the manilpulation of this record the event list. Platform specif locks
     // required.
     //
-    SDL_LockMutex(m_Mutex);
+#if SDL_MAJOR_VERSION < 3
+    SDL_LockMutex( (SDL_mutex*)m_Mutex );
+#else
+    SDL_LockMutex( m_Mutex );
+#endif
 
     while( (m_EventsQueued != 0) && (eventsToDispatch != 0) )
     {
@@ -361,7 +379,11 @@ unsigned int radDispatcher::Service( void )
         //
         // Now remove lock and invoke event handler.
         //
-        SDL_UnlockMutex(m_Mutex);
+#if SDL_MAJOR_VERSION < 3
+        SDL_UnlockMutex( (SDL_mutex*)m_Mutex );
+#else
+        SDL_UnlockMutex( m_Mutex );
+#endif
 
         event.m_Callback->OnDispatchCallack( event.m_UserData );
 
@@ -378,10 +400,18 @@ unsigned int radDispatcher::Service( void )
         RotateThreadReadyQueue( threadInfo.currentPriority );
         #endif
 
-        SDL_LockMutex(m_Mutex);
+#if SDL_MAJOR_VERSION < 3
+        SDL_LockMutex( (SDL_mutex*)m_Mutex );
+#else
+        SDL_LockMutex( m_Mutex );
+#endif
     }
 
-    SDL_UnlockMutex(m_Mutex);
+#if SDL_MAJOR_VERSION < 3
+    SDL_UnlockMutex( (SDL_mutex*)m_Mutex );
+#else
+    SDL_UnlockMutex( m_Mutex );
+#endif
 
     return( m_EventsQueued );
           

--- a/libs/radcore/src/raddispatch/dispatcher.hpp
+++ b/libs/radcore/src/raddispatch/dispatcher.hpp
@@ -26,9 +26,6 @@
 // Include Files
 //=============================================================================
 
-#include <SDL.h>
-
-
 #include <raddispatch.hpp>
 #include <radobject.hpp>
 #include <radmemory.hpp>
@@ -36,6 +33,8 @@
 //=============================================================================
 // Forward Class Declarations
 //=============================================================================
+
+struct SDL_Mutex;
 
 //=============================================================================
 // Class Declarations
@@ -107,7 +106,7 @@ class radDispatcher : public IRadDispatcher,
     unsigned int        m_EventQueueTailIndex;
     unsigned int        m_EventsQueued;
 
-    SDL_mutex*		m_Mutex;
+    SDL_Mutex*          m_Mutex;
 };
 
 #endif

--- a/libs/radcore/src/radplatform/platform.cpp
+++ b/libs/radcore/src/radplatform/platform.cpp
@@ -33,7 +33,9 @@
 #include <SDL.h>
 #ifdef WIN32
 #include <windows.h>
+#if SDL_MAJOR_VERSION < 3
 #include <SDL_syswm.h>
+#endif
 #endif
 #endif 
 #ifdef RAD_XBOX
@@ -119,7 +121,11 @@ class radPlatform : public IRadPlatform
     //
     // Windows specific interfaces.
     //
+#if SDL_MAJOR_VERSION < 3
     static int SDLCALL MainWindowProcedure
+#else
+    static bool SDLCALL MainWindowProcedure
+#endif
     (
         void* userdata, SDL_Event* event
     );
@@ -136,7 +142,7 @@ class radPlatform : public IRadPlatform
 		
         rWarningMsg( m_pMainWindow != NULL, "hMainWindow set to NULL in platform component" );
 
-#ifdef WIN32
+#if defined(WIN32) && SDL_MAJOR_VERSION < 3
         SDL_VERSION( &m_wmInfo.version );
         SDL_GetWindowWMInfo( pMainWindow, &m_wmInfo );
 #endif
@@ -151,14 +157,22 @@ class radPlatform : public IRadPlatform
 
 #ifdef WIN32
 	virtual HWND GetMainWindowHandle( void )
-    {   
+    {
+#if SDL_MAJOR_VERSION < 3
         rWarningMsg( m_wmInfo.subsystem == SDL_SYSWM_WINDOWS, "WM info doesn't match the windows subsystem." );
 
         return( m_wmInfo.info.win.window );
+#else
+        return (HWND)SDL_GetPointerProperty(SDL_GetWindowProperties(m_pMainWindow), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL);
+#endif
     }
     virtual HINSTANCE GetInstanceHandle( void )
     {
+#if SDL_MAJOR_VERSION < 3
         return( m_wmInfo.info.win.hinstance );
+#else
+        return (HINSTANCE)SDL_GetPointerProperty(SDL_GetWindowProperties(m_pMainWindow), SDL_PROP_WINDOW_WIN32_INSTANCE_POINTER, NULL);
+#endif
     }
 #endif
 
@@ -174,13 +188,17 @@ class radPlatform : public IRadPlatform
     {
         rAssert( pICallback != NULL );
 
+#if SDL_MAJOR_VERSION < 3
         SDL_DelEventWatch( MainWindowProcedure, pICallback );
+#else
+        SDL_RemoveEventWatch( MainWindowProcedure, pICallback );
+#endif
     }
 
     private:    
     
     SDL_Window* m_pMainWindow;
-#ifdef WIN32
+#if defined(WIN32) && SDL_MAJOR_VERSION < 3
     SDL_SysWMinfo m_wmInfo;
 #endif
 
@@ -543,7 +561,11 @@ void radPlatformInitialize( SDL_Window* pMainWindow, radMemoryAllocator allocato
     pthePlatform->Initialize( pMainWindow, allocator );
 }
 
+#if SDL_MAJOR_VERSION < 3
 int SDLCALL radPlatform::MainWindowProcedure
+#else
+bool SDLCALL radPlatform::MainWindowProcedure
+#endif
 (
     void* userdata, SDL_Event* event
 )
@@ -554,7 +576,7 @@ int SDLCALL radPlatform::MainWindowProcedure
 
     callback->OnWindowMessage( pThis->m_pMainWindow, event );
 
-    return 0;
+    return false;
 }
 
 #endif

--- a/libs/radcore/src/radthread/mutex.cpp
+++ b/libs/radcore/src/radthread/mutex.cpp
@@ -29,6 +29,8 @@
 #include "mutex.hpp"
 #include "system.hpp"
 
+#include <SDL.h>
+
 //=============================================================================
 // Local Definitions
 //=============================================================================
@@ -90,7 +92,11 @@ radThreadMutex::radThreadMutex( void )
     m_ReferenceCount( 1 )
 { 
     radMemoryMonitorIdentifyAllocation( this, g_nameFTech, "radThreadMutex" );
+#if SDL_MAJOR_VERSION < 3
+    m_Mutex = (SDL_Mutex*)SDL_CreateMutex();
+#else
     m_Mutex = SDL_CreateMutex();
+#endif
 }
 
 //=============================================================================
@@ -108,7 +114,11 @@ radThreadMutex::radThreadMutex( void )
 
 radThreadMutex::~radThreadMutex( void )
 {
+#if SDL_MAJOR_VERSION < 3
+    SDL_DestroyMutex((SDL_mutex*)m_Mutex);
+#else
     SDL_DestroyMutex(m_Mutex);
+#endif
 }
 
 //=============================================================================
@@ -126,8 +136,12 @@ radThreadMutex::~radThreadMutex( void )
 //------------------------------------------------------------------------------
 
 void radThreadMutex::Lock( void )
-{ 
+{
+#if SDL_MAJOR_VERSION < 3
+    SDL_LockMutex((SDL_mutex*)m_Mutex);
+#else
     SDL_LockMutex(m_Mutex);
+#endif
 }
 
 //=============================================================================
@@ -143,8 +157,12 @@ void radThreadMutex::Lock( void )
 //------------------------------------------------------------------------------
 
 void radThreadMutex::Unlock( void )
-{ 
+{
+#if SDL_MAJOR_VERSION < 3
+    SDL_UnlockMutex((SDL_mutex*)m_Mutex);
+#else
     SDL_UnlockMutex(m_Mutex);
+#endif
 }
 
 //=============================================================================

--- a/libs/radcore/src/radthread/mutex.hpp
+++ b/libs/radcore/src/radthread/mutex.hpp
@@ -24,7 +24,6 @@
 // Include Files
 //=============================================================================
 
-#include <SDL.h>
 #include <radobject.hpp>
 #include <radmemory.hpp>
 #include <radthread.hpp>
@@ -32,6 +31,8 @@
 //=============================================================================
 // Forward Class Declarations
 //=============================================================================
+
+struct SDL_Mutex;
 
 //=============================================================================
 // Defintions
@@ -82,7 +83,7 @@ class radThreadMutex : public IRadThreadMutex,
     //
     unsigned int m_ReferenceCount;    
 
-    SDL_mutex* m_Mutex;
+    SDL_Mutex* m_Mutex;
 };
 
 #endif

--- a/libs/radcore/src/radthread/semaphore.cpp
+++ b/libs/radcore/src/radthread/semaphore.cpp
@@ -30,6 +30,8 @@
 #include "semaphore.hpp"
 #include "system.hpp"
 
+#include <SDL.h>
+
 //=============================================================================
 // Local Definitions
 //=============================================================================
@@ -94,7 +96,7 @@ radThreadSemaphore::radThreadSemaphore( unsigned int count )
 { 
     radMemoryMonitorIdentifyAllocation( this, g_nameFTech, "radThreadSemaphore" );
 
-    m_Semaphore = SDL_CreateSemaphore(0);
+    m_Semaphore = (SDL_Semaphore*)SDL_CreateSemaphore(0);
 }
 
 //=============================================================================
@@ -112,7 +114,11 @@ radThreadSemaphore::radThreadSemaphore( unsigned int count )
 
 radThreadSemaphore::~radThreadSemaphore( void )
 {
+#if SDL_MAJOR_VERSION < 3
+    SDL_DestroySemaphore((SDL_sem*)m_Semaphore);
+#else
     SDL_DestroySemaphore(m_Semaphore);
+#endif
 }
 
 //=============================================================================
@@ -129,8 +135,12 @@ radThreadSemaphore::~radThreadSemaphore( void )
 //------------------------------------------------------------------------------
 
 void radThreadSemaphore::Wait( void )
-{ 
-    SDL_SemWait(m_Semaphore);
+{
+#if SDL_MAJOR_VERSION < 3
+    SDL_SemWait((SDL_sem*)m_Semaphore);
+#else
+    SDL_WaitSemaphore(m_Semaphore);
+#endif
 }
 
 //=============================================================================
@@ -146,8 +156,12 @@ void radThreadSemaphore::Wait( void )
 //------------------------------------------------------------------------------
 
 void radThreadSemaphore::Signal( void )
-{ 
-    SDL_SemPost(m_Semaphore);
+{
+#if SDL_MAJOR_VERSION < 3
+    SDL_SemPost((SDL_sem*)m_Semaphore);
+#else
+    SDL_SignalSemaphore(m_Semaphore);
+#endif
 }
 
 //=============================================================================

--- a/libs/radcore/src/radthread/semaphore.hpp
+++ b/libs/radcore/src/radthread/semaphore.hpp
@@ -24,8 +24,6 @@
 // Include Files
 //=============================================================================
 
-#include <SDL.h>
-
 #include <radobject.hpp>
 #include <radmemory.hpp>
 #include <radthread.hpp>
@@ -33,6 +31,8 @@
 //=============================================================================
 // Forward Class Declarations
 //=============================================================================
+
+struct SDL_Semaphore;
 
 //=============================================================================
 // Defintions
@@ -83,7 +83,7 @@ class radThreadSemaphore : public IRadThreadSemaphore,
     //
     unsigned int m_ReferenceCount;    
 
-    SDL_sem* m_Semaphore;
+    SDL_Semaphore* m_Semaphore;
 };
 
 #endif

--- a/libs/radcore/src/radthread/system.cpp
+++ b/libs/radcore/src/radthread/system.cpp
@@ -47,7 +47,11 @@ static bool g_SystemInitialized = false;
 //
 // Need an exclusion object for each of the various platforms.
 //
+#if SDL_MAJOR_VERSION < 3
 static SDL_mutex* g_ExclusionObject = nullptr;
+#else
+static SDL_Mutex* g_ExclusionObject = nullptr;
+#endif
 
 //=============================================================================
 // Public Functions

--- a/libs/radcore/src/radthread/thread.cpp
+++ b/libs/radcore/src/radthread/thread.cpp
@@ -30,6 +30,8 @@
 #include "system.hpp"
 #include "thread.hpp"
 
+#include <SDL.h>
+
 //=============================================================================
 // Local Definitions
 //=============================================================================
@@ -54,7 +56,7 @@ radThread* radThread::s_ThreadTable[ MAX_RADTHREADS ];
 // The following table are provided to map our priorities to OS specific 
 // priorities.
 //
-SDL_ThreadPriority radThread::s_PriorityMap[ PriorityHigh + 1 ] =
+static SDL_ThreadPriority s_PriorityMap[ radThread::PriorityHigh + 1 ] =
         { SDL_THREAD_PRIORITY_LOW, SDL_THREAD_PRIORITY_LOW, SDL_THREAD_PRIORITY_NORMAL,
           SDL_THREAD_PRIORITY_HIGH, SDL_THREAD_PRIORITY_HIGH };
 
@@ -559,7 +561,17 @@ radThread::radThread
     // Create thread which then sets its own priority.
     //
     m_Priority = priority;
+
+#if SDL_MAJOR_VERSION < 3
     m_ThreadHandle = SDL_CreateThreadWithStackSize(InternalThreadEntry, /*name*/nullptr, stackSize * 1024, this);
+#else
+    SDL_PropertiesID props = SDL_CreateProperties();
+    SDL_SetPointerProperty(props, SDL_PROP_THREAD_CREATE_ENTRY_FUNCTION_POINTER, (void*)InternalThreadEntry);
+    SDL_SetNumberProperty(props, SDL_PROP_THREAD_CREATE_STACKSIZE_NUMBER, (Sint64)(stackSize * 1024));
+    SDL_SetPointerProperty(props, SDL_PROP_THREAD_CREATE_USERDATA_POINTER, this);
+    m_ThreadHandle = SDL_CreateThreadWithProperties(props);
+    SDL_DestroyProperties(props);
+#endif
 
     //
     // Release our protection.
@@ -751,7 +763,11 @@ void radThread::SetPriority( Priority priority )
     //
     m_Priority = priority;
 
+#if SDL_MAJOR_VERSION < 3
     SDL_SetThreadPriority( s_PriorityMap[ priority ] );
+#else
+    SDL_SetCurrentThreadPriority( s_PriorityMap[ priority ] );
+#endif
 }
 
 //=============================================================================

--- a/libs/radcore/src/radthread/thread.hpp
+++ b/libs/radcore/src/radthread/thread.hpp
@@ -24,8 +24,6 @@
 // Include Files
 //=============================================================================
 
-#include <SDL.h>
-
 #include <radobject.hpp>
 #include <radmemory.hpp>
 #include <radthread.hpp>
@@ -33,6 +31,8 @@
 //=============================================================================
 // Forward Class Declarations
 //=============================================================================
+
+struct SDL_Thread;
 
 //=============================================================================
 // Defintions
@@ -257,9 +257,8 @@ class radThread : public IRadThread,
     //
     // Platform specific information used to manage the thread.
     //
-    SDL_threadID    m_ThreadId;
+    unsigned long   m_ThreadId;
     SDL_Thread*     m_ThreadHandle;
-    static SDL_ThreadPriority s_PriorityMap[ PriorityHigh + 1 ];
 
     //
     // Here we maintain the actual values used  by the thread local


### PR DESCRIPTION
SDL3 does not have any equivalent function to SDL_GetWindowGammaRamp and SDL_SetWindowGammaRamp, so they have been commented out but not removed, to have a reference in the future.

I was not really sure of the use those functions, so maybe you (or someone) can share a bit more insight. The official migration documentation mention that this could and probably should be implemented in the OpenGL layer.