### PR TITLE
Fix null check for options icon scaling

### DIFF
--- a/code/presentation/gui/minigame/guiscreenminimenu.cpp
+++ b/code/presentation/gui/minigame/guiscreenminimenu.cpp
@@ -444,7 +444,7 @@ CGuiScreenMiniMenu::CGuiScreenMiniMenu
 
 #ifdef RAD_WIN32
     Scrooby::Sprite* optionsIcon = m_optionsButton->GetSprite( "Options" );
-    if( optionsText != NULL )
+    if( optionsIcon != NULL )
     {
         optionsIcon->ScaleAboutCenter( BUTTON_SCALE );
     }


### PR DESCRIPTION


## Summary

This pull request fixes an incorrect null pointer check in `guiscreenminimenu.cpp`.

The code retrieves the `Options` sprite into `optionsIcon`, but the previous condition checked that `optionsText != NULL` before calling:

```cpp
optionsIcon->ScaleAboutCenter( BUTTON_SCALE );
```

This is obviously incorrect, and if we use the assets from the original PC version, which does not include those icons, it can cause a crash.

## Problem

In practice, this can cause a crash when trying to start the extra bonus race from the main menu / Homer’s house menu, preventing the bonus race, the race circuit option in Homer’s house, from launching correctly.

## Fix

The fix is to check `optionsIcon` before using it:

```cpp
Scrooby::Sprite* optionsIcon = m_optionsButton->GetSprite( "Options" );

if( optionsIcon != NULL )
{
    optionsIcon->ScaleAboutCenter( BUTTON_SCALE );
}
```

## User impact

This is a small code change, but it has a relevant user-facing impact: it can prevent a crash when launching the bonus race and allows the extra race menu flow to continue correctly.

## Credits

This issue was found collaboratively by me, @Carlox33, and @whyhuron.